### PR TITLE
IE9 compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -50,7 +49,7 @@ function Overlay(options) {
  * Inherits from `Emitter.prototype`.
  */
 
-Overlay.prototype.__proto__ = Emitter.prototype;
+Overlay.prototype = new Emitter;
 
 /**
  * Show the overlay.


### PR DESCRIPTION
This allows tests for "dialog" to work in IE9.

My IE9 understanding is too limited to know why.  I wish I did.
