### PR TITLE
change "hide" class to "hidden"

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ Emitter(Overlay.prototype);
 
 Overlay.prototype.show = function(){
   this.emit('show');
-  this.el.removeClass('hide');
+  this.el.removeClass('hidden');
   return this;
 };
 
@@ -102,7 +102,7 @@ Overlay.prototype.hide = function(){
 Overlay.prototype.remove = function(){
   var self = this;
   this.emit('close');
-  this.el.addClass('hide');
+  this.el.addClass('hidden');
   setTimeout(function(){
     self.el.remove();
   }, 2000);

--- a/overlay.css
+++ b/overlay.css
@@ -13,7 +13,7 @@
   z-index: 500;
 }
 
-.overlay.hide {
+.overlay.hidden {
   pointer-events: none;
   opacity: 0;
 }

--- a/template.html
+++ b/template.html
@@ -1,1 +1,1 @@
-<div class="overlay hide"></div>
+<div class="overlay hidden"></div>

--- a/template.js
+++ b/template.js
@@ -1,1 +1,1 @@
-module.exports = '<div class="overlay hide"></div>\n';
+module.exports = '<div class="overlay hidden"></div>\n';


### PR DESCRIPTION
i think it's more clear to use adjectives for these kinds of classes (i like to make them mimic the HTML standard, eg. `hidden`, `checked`, `active`, `empty`, etc.)
