### PR TITLE
when appending to body, use fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function Overlay(options) {
   this.target = options.target || 'body';
   this.closable = options.closable;
   this.el = o(tmpl);
+  if ('body' == this.target) this.el.addClass('fixed');
   this.el.appendTo(this.target);
   if (this.closable) this.el.on('click', this.hide.bind(this));
 }

--- a/overlay.css
+++ b/overlay.css
@@ -17,3 +17,7 @@
   pointer-events: none;
   opacity: 0;
 }
+
+.overlay.fixed {
+  position: fixed;
+}


### PR DESCRIPTION
using `position: fixed` when appending body gets rid of the awkward scrolling past the overlay bug that `absolute` makes possible. we have to check, since `fixed` doesn't work for nested overlays
