### PR TITLE
remove hardcoded timeout by listening on transitions

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,6 +7,7 @@
     "ui"
   ],
   "dependencies": {
+    "anthonyshort/after-transition": "0.0.2",
     "component/emitter": "1.0.0",
     "component/dom": "0.7.0"
   },

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  */
 
 var Emitter = require('emitter');
+var after = require('after-transition');
 var tmpl = require('./template');
 var o = require('dom');
 
@@ -100,12 +101,12 @@ Overlay.prototype.hide = function(){
  */
 
 Overlay.prototype.remove = function(){
-  var self = this;
   this.emit('close');
-  this.el.addClass('hide');
-  setTimeout(function(){
-    self.el.remove();
-  }, 2000);
+  var el = this.el;
+  el.addClass('hide');
+  after(el.get(0), function () {
+    el.remove();
+  });
   return this;
 };
 


### PR DESCRIPTION
really cool component by @anthonyshort that lets us remove hardcoded timeouts for waiting for transitions, looking to use overlay with a `.3s` transition instead and figured this would make a good fix
