### PR TITLE
Update package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,19 @@
     "event": "component-event",
     "classes": "component-classes"
   },
+  "browserify": {
+    "transform": [
+       "stringify"
+    ]
+  },
   "dependencies": {
     "emitter-component": "*",
     "component-event": "*",
     "domify": "*",
     "component-classes": "*"
+  },
+  "devDependencies": {
+    "stringify": "^3.1.0"
   },
   "component": {
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "emitter-component": "*",
     "component-event": "*",
     "domify": "*",
-    "component-classes": "*"
-  },
-  "devDependencies": {
+    "component-classes": "*",
     "stringify": "^3.1.0"
   },
   "component": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,16 @@
     "overlay",
     "ui"
   ],
+  "browser": {
+    "emitter": "emitter-component",
+    "event": "component-event",
+    "classes": "component-classes"
+  },
   "dependencies": {
     "emitter-component": "*",
-    "jquery-component": "*"
+    "component-event": "*",
+    "domify": "*",
+    "component-classes": "*"
   },
   "component": {
     "scripts": {


### PR DESCRIPTION
@tj, @juliangruber please also update npm package, as it has 0.1.0 now, which uses jquery as a dependency, which is unfortunate for dependent dialog-component.