### PR TITLE
component-emitter better than emitter-component

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ui"
   ],
   "browser": {
-    "emitter": "emitter-component",
+    "emitter": "component-emitter",
     "event": "component-event",
     "classes": "component-classes"
   },
@@ -17,7 +17,7 @@
     ]
   },
   "dependencies": {
-    "emitter-component": "*",
+    "component-emitter": "*",
     "component-event": "*",
     "domify": "*",
     "component-classes": "*",


### PR DESCRIPTION
The dialog component use `component-emitter` as package from npm, but overlay use `emitter-component` which just has lower version number. The result is redundant code is produced after build.
